### PR TITLE
Add Elixir-specific source code highlighting

### DIFF
--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -952,6 +952,72 @@ meta.property-value support.constant.named-color.css</string>
         <string>#C3E88D</string>
         </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Module Names</string>
+      <key>scope</key>
+      <string>source.elixir support.type.elixir, source.elixir meta.module.elixir entity.name.class.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#82AAFF</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Function definitions</string>
+      <key>scope</key>
+      <string>source.elixir entity.name.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffcb6b</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Atom</string>
+      <key>scope</key>
+      <string>source.elixir constant.other.symbol.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#F77669</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: String</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.definition.string</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#C3E88D</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Module Attribute</string>
+      <key>scope</key>
+      <string>source.elixir variable.other.readwrite.module.elixir, source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffcb6b</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Binaries</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.binary.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#c792eaff</string>
+      </dict>
+    </dict>
   </array>
   <key>uuid</key>
   <string>133d1250-19c6-4565-bc93-b37fd36f7fc9</string>

--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -945,6 +945,61 @@ meta.property-value support.constant.named-color.css</string>
         <string>#C3E88D</string>
         </dict>
     </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Module Names</string>
+      <key>scope</key>
+      <string>source.elixir support.type.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#EBB060</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Atom</string>
+      <key>scope</key>
+      <string>source.elixir constant.other.symbol.elixir, source.elixir constant.other.keywords.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#E53935</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: String</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.definition.string</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#99b89dff</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Module Attribute</string>
+      <key>scope</key>
+      <string>source.elixir variable.other.readwrite.module.elixir, source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#EBB060</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Binaries</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.binary.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#39ADB5</string>
+      </dict>
+    </dict>
 	</array>
 	<key>uuid</key>
 	<string>133d1250-19c6-4565-bc93-b37fd36f7fc9</string>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -939,6 +939,72 @@ meta.property-value support.constant.named-color.css</string>
         <string>#C3E88D</string>
         </dict>
     </dict>
+		<dict>
+      <key>name</key>
+      <string>Elixir: Module Names</string>
+      <key>scope</key>
+      <string>source.elixir support.type.elixir, source.elixir meta.module.elixir entity.name.class.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#82AAFF</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Function definitions</string>
+      <key>scope</key>
+      <string>source.elixir entity.name.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffcb6b</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Atom</string>
+      <key>scope</key>
+      <string>source.elixir constant.other.symbol.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#F77669</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: String</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.definition.string</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#C3E88D</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Module Attribute</string>
+      <key>scope</key>
+      <string>source.elixir variable.other.readwrite.module.elixir, source.elixir variable.other.readwrite.module.elixir punctuation.definition.variable.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffcb6b</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Elixir: Binaries</string>
+      <key>scope</key>
+      <string>source.elixir punctuation.binary.elixir</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#c792eaff</string>
+      </dict>
+    </dict>
 	</array>
 	<key>uuid</key>
 	<string>133d1250-19c6-4565-bc93-b37fd36f7fc9</string>


### PR DESCRIPTION
There were a few important pieces of code that weren't being highlighted properly in Elixir code. This made it hard to easily find things just by quickly scanning.

Before:
![](http://puu.sh/lRek7/344db6bb79.png)

After:
![](http://puu.sh/lRem0/16f3c92476.png)

As you can see, it's a lot easier for your eyes to quickly jump around.

Overall, there are four new items being highlighted, in a manner that is pretty typical amongst Elixir syntax highlighters:
- Module names (they were just white before, but they should be the same color as a "class name" would be
- Atoms (they were highlighted like strings, but they should be highlighted like constants)
- Module attributes like `@something 3` (these weren't highlighted but should be separate from most code)
- Binaries (only part of them were being highlighted, but now the complete syntax is highlighted consistently)

I know the changes are relatively minimal, but they truly make it a lot easier to work with Elixir in the Material Theme.
