### PR TITLE
Add Tasks Syntax support

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -60,11 +60,22 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, text.cancelled, meta.punctuation.separator</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
         <string>#444444</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>notes</string>
+      <key>scope</key>
+      <string>notes</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8EACE3</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -72,11 +72,22 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, text.cancelled, meta.punctuation.separator</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
         <string>#444444</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>notes</string>
+      <key>scope</key>
+      <string>notes</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8EACE3</string>
       </dict>
     </dict>
     <dict>
@@ -361,7 +372,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
       <key>name</key>
       <string>Bold</string>
       <key>scope</key>
-      <string>markup.bold, punctuation.definition.bold</string>
+      <string>markup.bold, punctuation.definition.bold, todo.bold</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>
@@ -374,7 +385,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
       <key>name</key>
       <string>Italic</string>
       <key>scope</key>
-      <string>markup.italic, punctuation.definition.italic</string>
+      <string>markup.italic, punctuation.definition.italic, todo.italic</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>

--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -61,13 +61,24 @@
 			<key>name</key>
 			<string>Comments</string>
 			<key>scope</key>
-			<string>comment, punctuation.definition.comment</string>
+			<string>comment, punctuation.definition.comment, text.cancelled, meta.punctuation.separator</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
 				<string>#B0BEC5</string>
 			</dict>
 		</dict>
+	    <dict>
+	      <key>name</key>
+	      <string>notes</string>
+	      <key>scope</key>
+	      <string>notes</string>
+	      <key>settings</key>
+	      <dict>
+	        <key>foreground</key>
+	        <string>#8EACE3</string>
+	      </dict>
+	    </dict>
 		<dict>
 			<key>name</key>
 			<string>Text and Source Base Colors</string>
@@ -350,7 +361,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 			<key>name</key>
 			<string>Bold</string>
 			<key>scope</key>
-			<string>markup.bold, punctuation.definition.bold</string>
+			<string>markup.bold, punctuation.definition.bold, todo.bold</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -363,7 +374,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 			<key>name</key>
 			<string>Italic</string>
 			<key>scope</key>
-			<string>markup.italic, punctuation.definition.italic</string>
+			<string>markup.italic, punctuation.definition.italic, todo.italic</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/schemes/Material-Theme-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-OceanicNext.tmTheme
@@ -60,11 +60,22 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, text.cancelled, meta.punctuation.separator</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
         <string>#546E7A</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>notes</string>
+      <key>scope</key>
+      <string>notes</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8EACE3</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -59,13 +59,24 @@
 			<key>name</key>
 			<string>Comments</string>
 			<key>scope</key>
-			<string>comment, punctuation.definition.comment</string>
+			<string>comment, punctuation.definition.comment, text.cancelled, meta.punctuation.separator</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
 				<string>#546E7A</string>
 			</dict>
 		</dict>
+	    <dict>
+	      <key>name</key>
+	      <string>notes</string>
+	      <key>scope</key>
+	      <string>notes</string>
+	      <key>settings</key>
+	      <dict>
+	        <key>foreground</key>
+	        <string>#8EACE3</string>
+	      </dict>
+	    </dict>
 		<dict>
 			<key>name</key>
 			<string>Text and Source Base Colors</string>
@@ -348,7 +359,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 			<key>name</key>
 			<string>Bold</string>
 			<key>scope</key>
-			<string>markup.bold, punctuation.definition.bold</string>
+			<string>markup.bold, punctuation.definition.bold, todo.bold</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>
@@ -361,7 +372,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 			<key>name</key>
 			<string>Italic</string>
 			<key>scope</key>
-			<string>markup.italic, punctuation.definition.italic</string>
+			<string>markup.italic, punctuation.definition.italic, todo.italic</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>


### PR DESCRIPTION
Add full Tasks syntax support for Material-Theme, Material-Theme-Darker
and Material-Theme-Lighter.
Add partial Tasks syntax support for Material-Theme-OceanicNext and
Material-Theme-Darker-OceanicNext as Bold and Italic were not managed
in those themes before
